### PR TITLE
Fix automerge and add options

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,5 +29,6 @@ jobs:
       with: 
         update_command: "echo updated > update.txt"
         on_changes_command: "echo changed > on_changes.txt"
+        pr_title: "PR from test run"
         automerge: false
   

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ jobs:
 | update_command | Command to update the dependencies | yes | just update-dependencies |
 | on_changes_command|A command to run if changes are detected|no|None|
 | token | The token that the action will use to create and update the pull request | no | GITHUB_TOKEN |
+| commit_message | Commit message if changes found| no | "chore: update-dependencies" |
+| pr_title | Pull request title | no | "Update dependencies |
 | automerge | Enable automerge on PRs created with the action | no | true |
 
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,16 @@ inputs:
     description: "The token that the action will use to create and update the pull request."
     default: ${{ github.token }}
 
+  commit_message:
+    description: "Commit message if changes found"
+    required: false
+    default: "chore: update-dependencies"
+  
+  pr_title:
+    description: "Title for the PR"
+    required: false
+    default: "Update dependencies"
+
   automerge: 
     description: "Enable automerge on PRs created by the action"
     default: true
@@ -42,8 +52,8 @@ runs:
         base: main
         author: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
         committer: "opensafely-github-bot <opensafely-github-bot@users.noreply.github.com>"
-        commit-message: "chore: Update dependencies"
-        title: "Update dependencies"
+        commit-message: ${{ inputs.commit_message }}
+        title: ${{ inputs.pr_title }}
         body: Automated changes by [update-dependencies-action](https://github.com/opensafely-core/update-dependencies-action)
         token: ${{ inputs.token }}
 

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
     # The PR will still need to pass any required checks, this just reduces it to a one-click process
     - name: Enable automerge
       shell: bash
-      if: ${{ (steps.create_pr.outputs.pull-request-operation == 'created') && (inputs.automerge) }}
+      if: ${{ (steps.create_pr.outputs.pull-request-operation == 'created') && (inputs.automerge == 'true') }}
       run: gh pr merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}
       env:
         GH_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
Fix automerge option - was previously always running, even if `false`.

Add options to customise PR title and commit message. 