### PR TITLE
Support custom PR body/description

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ jobs:
 | commit_message | Commit message if changes found| no | "chore: update-dependencies" |
 | pr_title | Pull request title | no | "Update dependencies" |
 | pr_label | Label to apply to pull requests created by the action | no | None |
+| pr_body | The body of the pull request. | no | "Automated changes by [update-dependencies-action](https://github.com/bennettoxford/update-dependencies-action)" |
 | automerge | Enable automerge on PRs created with the action | no | true |
 | sign-commits | Sign commits as `github-actions[bot]` when using `GITHUB_TOKEN`, or your own bot when using GitHub App tokens. | no | true |
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,11 @@ inputs:
     description: "Label to apply to PRs created by the action"
     required: false
 
+  pr_body:
+    description: "The body of the PR"
+    required: false
+    default: "Automated changes by [update-dependencies-action](https://github.com/bennettoxford/update-dependencies-action)"
+
   automerge: 
     description: "Enable automerge on PRs created by the action"
     default: true
@@ -79,7 +84,7 @@ runs:
         commit-message: ${{ inputs.commit_message }}
         title: ${{ inputs.pr_title }}
         labels: ${{ inputs.pr_label }}
-        body: Automated changes by [update-dependencies-action](https://github.com/bennettoxford/update-dependencies-action)
+        body: ${{ inputs.pr_body }}
         token: ${{ inputs.token }}
         sign-commits: ${{ inputs.sign-commits }}
 


### PR DESCRIPTION
Add a new option for providing a custom PR description.

I want to use the update-dependencies-action to do lockfile maintenance for BennettBot, until Renovate catches up and fixes the cooldown for uv.  But I'd like to add a custom PR body that tell you to merge Renovate PRs first (so this one only has to handle transitive dependencies)